### PR TITLE
Fetch Python CI version from the place where it's used

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,8 @@ jobs:
       - name: python
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
-          python-version: ${{steps.tool-versions.outputs.python}}
+          # renovate datasource: github-tags, depName: actions/python-versions
+          python-version: 3.11.0
 
       - name: wheel
         run: pip3 install wheel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           # renovate datasource: github-tags, depName: actions/python-versions
-          python-version: 3.11.0
+          python-version: 3.11.9
 
       - name: wheel
         run: pip3 install wheel


### PR DESCRIPTION
# Description

This might imply that, at times, `.tool-versions` and CI might not be in agreement, but this'll be temporarily (hopefully) and also (hopefully) not cause issues for pull requests.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/paulo-ferraz-oliveira/asdf-awscli-local/blob/main/CONTRIBUTING.md)
