### PR TITLE
Renovate: update to my most recent Gist version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    ":pinDevDependencies",
+    ":pinDigestsDisabled"
   ],
   "packageRules": [
     {
@@ -10,6 +13,31 @@
         ".tool-versions"
       ],
       "groupName": "dev tools"
+    },
+    {
+      "matchFileNames": [
+        "rebar.config"
+      ],
+      "groupName": "rebar.config deps"
+    },
+    {
+      "matchFileNames": [
+        "package.json",
+        ".nvmrc"
+      ],
+      "groupName": "package.json + .nvmrc deps"
+    },
+    {
+      "matchFileNames": [
+        "Dockerfile"
+      ],
+      "groupName": "Docker deps"
+    },
+    {
+      "matchPackagePrefixes": [
+        "minimum_otp_vsn"
+      ],
+      "enabled": false
     }
   ],
   "customManagers": [
@@ -20,8 +48,31 @@
         ".github/.*/.*\\.yml"
       ],
       "matchStrings": [
-        "# renovate datasource: (?<datasource>[^,]+), depName: (?<depName>[^\\n]+)\\n[^\\d]+(?<currentValue>v?\\d+(\\.\\d+)?(\\.\\d+)?)"
+        "# renovate datasource: (?<datasource>[^,]+), depName: (?<depName>[^\\n]+)\\n.+?(?<currentValue>v?\\d+(\\.\\d+(\\.\\d+)?)?(-[^\\n]+)?)\\n"
       ]
+    },
+    {
+      "description": "Match versions in rebar.config",
+      "customType": "regex",
+      "fileMatch": [
+        "rebar.config"
+      ],
+      "datasourceTemplate": "hex",
+      "matchStrings": [
+        "{(?<depName>[^,]+), \"(?<currentValue>\\d+\\.\\d+(\\.\\d+)?)\""
+      ],
+      "versioningTemplate": "semver"
+    },
+    {
+      "description": "Match versions (per datasource and depName) in Dockerfile",
+      "customType": "regex",
+      "fileMatch": [
+        "Dockerfile"
+      ],
+      "matchStrings": [
+        "# renovate datasource: (?<datasource>[^,]+), depName: (?<depName>[^\\n]+)\\nENV .+?_VERSION=\"(?<currentValue>[^\"]+)\""
+      ],
+      "versioningTemplate": "loose"
     }
   ]
 }


### PR DESCRIPTION
# Description

I think since versions in `actions/python-versions` are not SemVer (and the `revanote.json` version used in this repo doesn't take `-...` into account) Renovate's having difficulty picking a version up.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/paulo-ferraz-oliveira/asdf-awscli-local/blob/main/CONTRIBUTING.md)
