### PR TITLE
BREAKING: new way to list versions (requires `pip >= 21.2`)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ Also, for testing locally use:
 ```shell
 # Replace <user> with your GitHub user name
 # Replace <branch> with the branch you pushed
-asdf plugin test awscli-local https://github.com/<user>/asdf-awscli-local.git "awslocal --version" --asdf-plugin-gitref <branch>
+asdf plugin test awscli-local git@github.com:<user>/asdf-awscli-local.git "awslocal --version" --asdf-plugin-gitref <branch>
 ```
 <!-- markdownlint-enable -->
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -23,7 +23,7 @@ list_all_versions() {
 	sed -i'.bak' -e 's/Available versions: //g' "$v"
 	sed -i'.bak' -e 's/.*)//g' "$v"
 	sed -i'.bak' -e 's/,//g' "$v"
-	tr -d '\n' < "$v" > "$v.new"
+	tr -d '\n' <"$v" >"$v.new"
 	rm -f "$v.bak" || true
 	cat "$v.new"
 }

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -18,12 +18,13 @@ list_all_versions() {
 	v="$plugin_dir/versions.txt"
 
 	set +e
-	pip3 install --user awscli-local== 2>"$v"
+	pip3 index versions awscli-local >"$v" 2>/dev/null
 	set -e
-	sed -i'.bak' -e 's/.*from versions: //g' "$v"
-	sed -i'.bak' -e 's/)//g' "$v"
+	sed -i'.bak' -e 's/Available versions: //g' "$v"
+	sed -i'.bak' -e 's/.*)//g' "$v"
 	sed -i'.bak' -e 's/,//g' "$v"
-	grep -v ERROR "$v" >"$v.new"
+	tr -d '\n' < "$v" > "$v.new"
+	rm -f "$v.bak" || true
 	cat "$v.new"
 }
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -89,7 +89,7 @@ install_version() {
 install_localstack() {
 	local install_path=$1
 
-	localstack_client_tar_gz=$(find "$install_path" -name "localstack-client*")
+	localstack_client_tar_gz=$(find "$install_path" -name "localstack_client*")
 	tar zxf "$localstack_client_tar_gz" --strip-components=1 -C "$install_path"
 
 	localstack_client=$(find "$install_path" -name "localstack_client")


### PR DESCRIPTION
# Description

We were using a "hack" before, and now we're using an experimental command, `pip3 index versions`, but this is breaking because it implies you're using at least `pip` 21.2.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/paulo-ferraz-oliveira/asdf-awscli-local/blob/main/CONTRIBUTING.md)
